### PR TITLE
Review inline section

### DIFF
--- a/docs/tutorial/inline.md
+++ b/docs/tutorial/inline.md
@@ -3,14 +3,15 @@ id: inline
 title: Inline
 ---
 
-Inlining is a common compile-time meta-programming technique for performance optimizations.
-Scala 3 makes several improvements related to inlining:
+Inlining is a common compile-time meta-programming technique, typically used to achieve performance optimizations. As we will see, in Scala 3, the concept of inlining provides us with an entrypoint to programming with macros.
+
+Compared to the previous versions, Scala 3 makes several improvements related to inlining:
 
 1. It introduces inline as a [soft keyword][soft-modifier].
 2. It guarantees that inlining actually happens instead of being best-effort.
 3. It introduces operations that are guaranteed to evaluate at compiletime.
 
-## Inline constants
+## Inline Constants
 
 The simplest form of inlining is to inline constants in programs:
 
@@ -20,7 +21,7 @@ inline val pi = 3.141592653589793
 inline val pie = "🥧"
 ```
 
-The usage of the keyword `inline` above *guarantees* that all references to `pi` and `pie` are inlined:
+The usage of the keyword `inline` in the _inline value definitions_ above *guarantees* that all references to `pi` and `pie` are inlined:
 
 ```scala
 val pi2 = pi + pi // val pi2 = 6.283185307179586
@@ -28,19 +29,20 @@ val pie2 = pie + pie // val pie2 = "🥧🥧"
 ```
 
 In the code above, the references `pi` and `pie` are inlined.
-Then constant folding optimization in the compiler will compute the resulting value `pi2` and `pie2` at _compile-time_.
+Then an optimization called "constant folding" is applied by the compiler, which  computes the resulting value `pi2` and `pie2` at _compile-time_.
 
-In Scala 2, we would have used the modifier `final` in the definition that is without a return type:
-
-```scala
-final val pi = 3.141592653589793
-final val pie = "🥧"
-```
-
-The `final` modifier will ensure that `pi` and `pie` will take a _literal type_.
-Then the constant propagation optimization in the compiler can perform inlining for such definitions.
-However, inlining based constant propagation is _best-effort_ and not guaranteed.
-The `final val` inlining is also supported by Scala 3.0 as _best-effort_ inlining for migration purposes.
+> #### Inline (Scala 3) vs. final (Scala 2)
+> In Scala 2, we would have used the modifier `final` in the definition that is  without a return type:
+>
+> ```scala
+> final val pi = 3.141592653589793
+> final val pie = "🥧"
+> ```
+>
+> The `final` modifier will ensure that `pi` and `pie` will take a _literal type_.
+> Then the constant propagation optimization in the compiler can perform inlining for such definitions.
+> However, this form of constant propagation is _best-effort_ and not guaranteed.
+> Scala 3.0 also supports `final val`-inlining as _best-effort_ inlining for migration purposes.
 
 Currently, only constant expression may appear on the right-hand side of an inline value definition.
 Therefore, the following code is invalid, though the compiler knows that the right-hand side is a compile-time constant value:
@@ -49,30 +51,34 @@ Therefore, the following code is invalid, though the compiler knows that the rig
 val pi = 3.141592653589793
 inline val pi2 = pi + pi // error
 ```
-
+Note that defining `pi` as an inline value definition, the addition can be
+computed at compile time. This resolves the aboev error and
+`pi2` will receive the literal type `6.283185307179586 : Double`.
 
 ## Inline Methods
 
-We can use the modifier `inline` to define a method that should be inlined at call-site:
+We can also use the modifier `inline` to define a method that should be inlined at the call-site:
 
 ```scala
-inline def logged[T](level: Int, message: => String)(inline op: T): Unit =
+inline def logged[T](level: Int, message: => String)(inline op: T): T =
   println(s"[$level]Computing $message")
   val res = op
   println(s"[$level]Result of $message: $res")
   res
 ```
 
-When this method is called, its body will be applied at compile-time over its passed arguments!
-This results in the replacement of the call by the body of the method with all parameters substituted correspondingly.
-Therefore, the following code 
+When an inline method like `logged` is called, its body will be expanded at the
+call-site at compile time! That is, the call to `logged` will be replaced by the
+body of the method. The provided arguments are statically substituted for
+the parameters of `logged`, correspondingly.
+Therefore, the compiler inlines the following call
 
 ```scala
 logged(logLevel, getMessage()) {
   computeSomthing()
 }
 ```
-would be inlined and becomes
+and rewrites it to:
 
 ```Scala
 val level   = logLevel
@@ -84,24 +90,27 @@ println(s"[$level]Result of $tag: $res")
 res
 ```
 
-Method inlining handles three kinds of parameters differently:
+### Semantics of Inline Methods
+Our example method `logged` uses three different kinds of parameters, illustrating
+that inlining handles those parameters differently:
 
-1. __By-value parameters__. The compiler generates a `val` binding for *by-value* parameters.
+1. __By-value parameters__. The compiler generates a `val` binding for *by-value* parameters. This way, the argument expression is evaluated only once before the method body is reduced.
 
     This can be seen in the parameter `level` from the example.
     In some cases, when the arguments are pure constant values, the binding is omitted and the value is inlined directly.
 
-2. __By-Name parameters__. The compiler generates a `def` binding for *by-name* parameters. 
+2. __By-Name parameters__. The compiler generates a `def` binding for *by-name* parameters. This way, the argument expression is evaluated every time it is used, but the code is shared.
 
     This can be seen in the parameter `message` from the example.
 
-3. __Inline parameters__. Inline parameters do not create bindings and their code is duplicated everywhere they are used.
+3. __Inline parameters__. Inline parameters do not create bindings and are simply inlined. This way, their code is duplicated everywhere they are used.
 
     This can be seen in the parameter `op` from the example.
 
-It is important to understand that when a call is inlined it **will not change** its semantics.
+The way the different parameters are translated guarantees that inlining a call **will not change** its semantics.
 This implies that the initial elaboration (overloading resolution, implicit search, ...), performed while typing the body of the inline method, will not change when inlined.
-For example consider the following code: 
+
+For example consider the following code:
 
 ```scala
 class Logger:
@@ -131,35 +140,34 @@ logger.log(x)
 ```
 Even though now we know that `x` is a `String`, the call `logger.log(x)` still resolves to the method `Log.log` which takes an argument of the type `Any`.
 
-Another way to interpret this is that if `logged` is a `def` or `inline def` they would perform the same operations with some differences in performance.
+> #### Inlining preserves semantics
+> Regardless of whether `logged` is defined as a `def` or `inline def`, it performs the same operations with only some differences in performance.
 
-### Inline parameters
+### Inline Parameters
 
 One important application of inlining is to enable constant folding optimization across method boundaries.
 Inline parameters do not create bindings and their code is duplicated everywhere they are used.
 
 ```scala
-inline def perimeter(inline radius: Double): Double = 
-  2. * pi * radius
+inline def perimeter(inline radius: Double): Double =
+  2.0 * pi * radius
 ```
-In this case, we expect that if the `radius` is known then the whole computation can be done at compile-time.
-We use an `inline` parameter to enforce the requirement.
-The follwing code
+In the above example, we expect that if the `radius` is statically known then the whole computation can be performed at compile-time. The following call
 
 ```scala
-perimeter(5.)
+perimeter(5.0)
 ```
 
-is inlined as 
+is rewritten to:
 
 ```Scala
-2. * pi * 5.
+2.0 * pi * 5.0
 ```
 
 Then `pi` is inlined (we assume the `inline val` definition from the start):
 
 ```Scala
-2. * 3.141592653589793 * 5.
+2.0 * 3.141592653589793 * 5.0
 ```
 
 Finally, it is constant folded to
@@ -168,62 +176,63 @@ Finally, it is constant folded to
 31.4159265359
 ```
 
-Be careful when using an inline parameter more than once.
-Consider the following code:
+> #### Inline parameters should be used only once
+> We need to be careful when using an inline parameter **more than once**.
+> Consider the following code:
+>
+> ```scala
+> inline def printPerimeter(inline radius: Double): Double =
+>   println(s"Perimeter (r = $radius) = ${perimeter(radius)}")
+> ```
+> It works perfectly fine when a constant or reference to a val is passed to it.
+> ```scala
+> printPerimeter(5.0)
+> // inlined as
+> println(s"Perimeter (r = ${5.0}) = ${31.4159265359}")
+> ```
+>
+> But if a larger expression (possibly with side-effects) is passed, we might accidentally duplicate work.
+>
+> ```scala
+> printPerimeter(longComputation())
+> // inlined as
+> println(s"Perimeter (r = ${longComputation()}) = ${6.283185307179586 * longComputation()}")
+> ```
+
+A useful application of inline parameters is to avoid the creation of _closures_, incurred by the use of by-name parameters.
 
 ```scala
-inline def printPerimeter(inline radius: Double): Double =
-  println(s"Perimeter (r = $radius) = ${perimeter(radius)}")
-```
-It works perfectly fine when a constant or reference to a val is passed to it.
-```scala
-printPerimeter(5.) 
-// inlined as
-println(s"Perimeter (r = ${5.}) = ${31.4159265359}")
-```
-
-But if something larger, possibly with side-effects is passed, then we might accidentally duplicate some work.
-
-```scala
-printPerimeter(longComputation()) 
-// inlined as
-println(s"Perimeter (r = ${longComputation()}) = ${6.283185307179586 * longComputation()}")
-```
-
-A useful application of inline parameters is to avoid the creation of closures of by-name parameters.
-
-```scala
-def assert1(cond: Boolean, msg: =>String) =
-  if !cond then 
+def assert1(cond: Boolean, msg: => String) =
+  if !cond then
     throw new Exception(msg)
 
 assert1(x, "error1")
 // is inlined as
 val cond = x
 def msg = "error1"
-if !cond then 
+if !cond then
     throw new Exception("error1")
 ```
-In this case, we can see that the closure for `msg` is created before the condition is checked.
+In the above example, we can see that the use of a by-name parameter leads to a local definition `msg`, which allocates a closure before the condition is checked.
 
 If we use an inline parameter instead, we can guarantee that the condition is checked before any of the code that handles the exception is reached.
 In the case of an assertion, this code should never be reached.
 ```scala
 inline def assert2(cond: Boolean, inline msg: String) =
-  if !cond then 
+  if !cond then
     throw new Exception(msg)
 
 assert2(x, "error2")
 // is inlined as
 val cond = x
-if !cond then 
+if !cond then
     throw new Exception("error2")
 ```
 
 ### Inline Conditionals
-If the condition of the inline is a known constant (`true` or `false`), possibly after inlining, then the `if` or `else`-branch is partially evaluated away and only one branch will be kept.
+If the condition of an `if` is a known constant (`true` or `false`), possibly after inlining and constant folding, then the conditional is partially evaluated and only one branch will be kept.
 
-For example, the following power method contains some `if` that will unroll the recursion and remove all method calls.
+For example, the following power method contains some `if` that will potentially unroll the recursion and remove all method calls.
 
 ```scala
 inline def power(x: Double, inline n: Int): Double =
@@ -231,7 +240,7 @@ inline def power(x: Double, inline n: Int): Double =
   else if (n % 2 == 1) x * power(x, n - 1)
   else power(x * x, n / 2)
 ```
-
+Calling `power` with statically known constants results in the following code:
   ```scala
   power(2, 2)
   // first inlines as
@@ -272,12 +281,15 @@ x2 * 1.0
 ```
 </details>
 
-
-Now imagine if we do not know the value of `n`
+In contrast, let us imagine we do not know the value of `n`:
 
 ```scala
 power(2, unkownNumber)
 ```
+Driven by the inline annotation on the parameter, the compiler will try to
+unroll the recursion. But without any success, since the parameter is not
+statically known.
+
 <details>
   <summary>See inlining steps</summary>
 
@@ -306,9 +318,10 @@ else {
 ```
 </details>
 
-Instead, we can use the `inline if` variant of `if` that ensures that the branching desition is performed at compile-time.
-It will always remove them if after inlining and keep a single branch before inlining the contents of the branch.
-If it does not have a constant condition it will emit an error and stop inlining.
+To guarantee that the branching can indeed be performed at compile-time, we can use the `inline if` variant of `if`.
+Annotating a conditional with `inline` will guarantee that the conditional can
+be reduced at compile-time and emits an error if the condition is not a
+statically known constant.
 
 ```scala
 inline def power(x: Double, inline n: Int): Double =
@@ -324,113 +337,14 @@ power(2, unkownNumber) // error
 
 We will come back to this example later and see how we can get more control on how code is generated.
 
-## Inline Method Overloading
-
-When combining `inline def` with overriding and interfaces we will have some restrictions to ensure the correct behavior of the methods.
-
-The first restriction is that all inline methods are effectively final.
-This ensures that the overload resolution at compile-time behaves the same as the one at runtime.
-
-Inline overrides must have the same signature as the overridden method including the inline parameters.
-This ensures that the call semantics are the same for both methods.
-
-A new concern appears when we implement or override a normal method with an inline method.
-Consider the following example:
-
-```scala
-trait Logger:
-  def log(x: Any): Unit
-
-class PrintLogger extends Logger:
-  inline def log(x: Any): Unit = println(x)
-```
-Now it is possible to call the `log` method directly on `PrintLogger` which will inline the code but we could also call it on `Logger`.
-This implies that the code of log must exist at runtime, we call this a _retained inline_ method.
-
-For any non-retained inline `def` or `val` the code can always be fully inlined at all call sites.
-Hence the methods will not be needed at runtime and can be erased from the bytecode.
-
-Retained inline methods must contain code that works when it is not inlined.
-An `inline if` as in the `power` example will not work as the `if` cannot be constant folded inside the definition `power`.
-Other cases involve metaprogramming constructs that only have meaning when inlined.
-
-It is also possible to create abstract inline definitions.
-
-```scala
-trait InlineLogger:
-  inline def log(inline x: Any): Unit
-
-class PrintLogger inline InlineLogger:
-  inline def log(inline x: Any): Unit = println(x)
-```
-
-This forces the implementation of `log` to be an inline method and also allows `inline` parameters.
-Unintuitively, the `log` in `Logger` cannot be called, this would result in an error as we do not know what to inline.
-Its usefulness becomes apparent when we use it in another inline method
-
-```scala
-inline def logged(logger: Logger, x: Any) =
-  logger.log(x)
-```
-
-```scala
-logged(new PrintLogger, "🥧")
-// inlined as
-val logger: PrintLogger = new PrintLogger
-logger.log(x)
-```
-
-In this case, when inlined, the call to `log` is de-virtualized and known to be on `PrintLogger`.
-Therfore the code can bee inlined.
-
-#### Summary of inline methods
-* All `inline` methods are final.
-* Abstract `inline` methods can only be implemented by inline methods.
-* If an inline method overrides/implements a normal method then it must be retained.
-* Retained methods cannot have inline parameters.
-
-
-## Transparent Inline
-This is a simple yet powerful extension to `inline` methods that unlocks many metaprogramming usescases.
-These inline calls allow for an inline piece of code to refine the type based on the precise type of the inlined expression.
-In Scala 2 parlance, these capture the essence of _whitebox macros_.
-
-```scala
-transparent def default(inline name: String): Any =
-  inline if name == "Int" then 0
-  else inline if name == "String" then ""
-  else ...
-```
-
-```scala
-val n0: Int = default("Int")
-val s0: String = default("String")
-```
-
-Note that even if the return type of `default` in `Any`, the first call is typed as an `Int` and the second as a `String`.
-The return type represents the upper bound of the type within the inlined term.
-We could also have been more precise and have written instead
-```scala
-transparent def default(inline name: String): 0 | "" = ...
-```
-
-The return type is also important when the inline method is recursive.
-There it should be precise enough for the recursion to type but will get more precise after inlining.
-
-
-It is important to note that changing the body of a `transparent inline def` will change how the call site is typed.
-This implies that the body plays a part in the binary and source compatibility of this interface.
-
-
 ### Inline Matches
+Like inline `if`, inline matches guarantee that the pattern matching can be
+statically reduced at compile time and only one branch is kept.
 
-Inline matches behave differently than normal matches.
-This variant provides a way to match on the static type of some expression.
-It ensures that only one branch is kept.
-In the following example, the scrutinee, x, is an inline parameter that we can pattern match on at compile time.
+In the following example, the scrutinee, `x`, is an inline parameter that we can pattern match on at compile time.
 
 ```scala
-transparent inline def half(x: Any): Any =
+inline def half(x: Any): Any =
   inline x match
     case x: Int => x / 2
     case x: String => x.substring(0, x.length / 2)
@@ -445,13 +359,118 @@ half("hello world")
 // val x = "hello world"
 // x.substring(0, x.length / 2)
 ```
-
-As we match on the static type of an expression, the following would fail to compile because at compile time there is not enough information to decide which branch to take.
+This illustrates that inline matches provide a way to match on the static type of some expression.
+As we match on the _static_ type of an expression, the following code would fail to compile.
 
 ```scala
 val n: Any = 3
 half(n) // error: n is not statically known to be an Int or a Double
 ```
+Notably, The value `n` is not marked as `inline` and in consequence at compile time
+there is not enough information about the scrutinee to decide which branch to take.
+
+
+### Inline Method Overriding
+
+To ensure the correct behavior of combining the static feature of `inline def` with
+the dynamic feature of interfaces and overriding, some restrictions have to be
+imposed.
+
+#### Effectively final
+Firstly, all inline methods are _effectively final_.
+This ensures that the overload resolution at compile-time behaves the same as the one at runtime.
+
+#### Signature preservation
+Secondly, overrides must have the _exact same signature_ as the overridden method including the inline parameters.
+This ensures that the call semantics are the same for both methods.
+
+#### Retained inline methods
+It is possible to implement or override a normal method with an inline method.
+Consider the following example:
+
+```scala
+trait Logger:
+  def log(x: Any): Unit
+
+class PrintLogger extends Logger:
+  inline def log(x: Any): Unit = println(x)
+```
+However, calling the `log` method directly on `PrintLogger` will inline the code, while calling it on `Logger` will not. To also admit the latter, the code of `log` must exist at runtime.
+We call this a _retained inline_ method.
+
+For any non-retained inline `def` or `val` the code can always be fully inlined at all call sites. Hence, those methods will not be needed at runtime and can be erased from the bytecode.
+However, retained inline methods must be compatible with the case that they are not inlined.
+In particular, retained inline methods cannot take any inline parameters.
+Furthermore, an `inline if` (as in the `power` example) will not work, since the `if` cannot be constant folded in the retained case.
+Other examples involve metaprogramming constructs that only have meaning when inlined.
+
+#### Abstract inline methods
+It is also possible to create _abstract inline definitions_.
+
+```scala
+trait InlineLogger:
+  inline def log(inline x: Any): Unit
+
+class PrintLogger inline InlineLogger:
+  inline def log(inline x: Any): Unit = println(x)
+```
+
+This forces the implementation of `log` to be an inline method and also allows `inline` parameters.
+Maybe unintuitively, the `log` on the interface `InlineLogger` cannot be directly called. The method implementation is not statically known and we thus do not know what to inline. Calling an abstract inline methods thus results in an error.
+The usefuleness of abstract inline methods becomes apparent when used in another inline method:
+
+```scala
+inline def logged(logger: Logger, x: Any) =
+  logger.log(x)
+```
+Let us assume a call to `logged` on a concrete instance of `PrintLogger`:
+```scala
+logged(new PrintLogger, "🥧")
+// inlined as
+val logger: PrintLogger = new PrintLogger
+logger.log(x)
+```
+After inlining, the call to `log` is de-virtualized and known to be on `PrintLogger`.
+Therfore also the code of `log` can be inlined.
+
+#### Summary of inline methods
+* All `inline` methods are final.
+* Abstract `inline` methods can only be implemented by inline methods.
+* If an inline method overrides/implements a normal method then it must be retained and retained methods cannot have inline parameters.
+* Abstract `inline` methods cannot be called directly (except in inline code).
+
+
+## Transparent Inline Methods
+Transparent inlines are a simple, yet powerful, extension to `inline` methods and unlock many metaprogramming usecases.
+Calls to transparents allow for an inline piece of code to refine the return type based on the precise type of the inlined expression.
+In Scala 2 parlance, transparents capture the essence of _whitebox macros_.
+
+```scala
+transparent inline def default(inline name: String): Any =
+  inline if name == "Int" then 0
+  else inline if name == "String" then ""
+  else ...
+```
+
+```scala
+val n0: Int = default("Int")
+val s0: String = default("String")
+```
+
+Note that even if the return type of `default` is `Any`, the first call is typed as an `Int` and the second as a `String`.
+The return type represents the upper bound of the type within the inlined term.
+We could also have been more precise and have written instead
+```scala
+transparent inline def default(inline name: String): 0 | "" = ...
+```
+While in this example it seems the return type is not necessary, it
+is important when the inline method is recursive.
+There it should be precise enough for the recursion to type but will get more precise after inlining.
+
+> #### Transparents affect binary compatibility
+> It is important to note that changing the body of a `transparent inline def` will change how the call site is typed.
+> This implies that the body plays a part in the binary and source compatibility of this interface.
+
 
 
 ## scala.compiletime
@@ -463,7 +482,7 @@ Macros provide a way to control the code generation and analysis after the call 
 
 
 ```scala
-inline def power(x: Double, inline n: Int) = 
+inline def power(x: Double, inline n: Int) =
   ${ powerCode('x, 'n)  }
 
 def powerCode(x: Expr[Double], n: Expr[Int])(using QuoteContext): Expr[Double] = ...

--- a/docs/tutorial/inline.md
+++ b/docs/tutorial/inline.md
@@ -335,8 +335,7 @@ We will come back to this example later and see how we can get more control on h
 
 ### Inline Method Overriding
 
-To ensure the correct behavior of combining the static feature of `inline def` with the dynamic feature of interfaces and overriding, some restrictions have to be
-imposed.
+To ensure the correct behavior of combining the static feature of `inline def` with the dynamic feature of interfaces and overriding, some restrictions have to be imposed.
 
 #### Effectively final
 Firstly, all inline methods are _effectively final_.
@@ -381,7 +380,8 @@ class PrintLogger inline InlineLogger:
 ```
 
 This forces the implementation of `log` to be an inline method and also allows `inline` parameters.
-Counterintuitively, the `log` on the interface `InlineLogger` cannot be directly called. The method implementation is not statically known and we thus do not know what to inline. Calling an abstract inline methods thus results in an error.
+Counterintuitively, the `log` on the interface `InlineLogger` cannot be directly called. The method implementation is not statically known and we thus do not know what to inline.
+Calling an abstract inline methods thus results in an error.
 The usefuleness of abstract inline methods becomes apparent when used in another inline method:
 
 ```scala
@@ -428,8 +428,7 @@ We could also have been more precise and have written instead
 ```scala
 transparent inline def default(inline name: String): 0 | "" = ...
 ```
-While in this example it seems the return type is not necessary, it
-is important when the inline method is recursive.
+While in this example it seems the return type is not necessary, it is important when the inline method is recursive.
 There it should be precise enough for the recursion to type but will get more precise after inlining.
 
 > #### Transparents affect binary compatibility

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -9,23 +9,16 @@ The metaprogramming API of Scala 3 is designed in layers to gradually
 support different levels of use-cases. Each successive layer exposes additional
 abstractions and offers more fine-grained control.
 
-- As a starting point, the new [`inline` feature](inline) allows some abstractions
-  (values and methods) to be marked as statically reducible. It can be used to
-  optimize performance by specializing code and also provides the entry point
-  for macros.
+- As a starting point, the new [`inline` feature](inline) allows some abstractions (values and methods) to be marked as statically reducible. 
+  It can be used to optimize performance by specializing code and also provides the entry point for macros.
 
-- [Compile-time operations](compile-time-operations) offer additional metaprogramming
-  utilities that can be used within `inline` methods (for example to improve error reporting),
-  without having to define a macro.
+- [Compile-time operations](compile-time-operations) offer additional metaprogramming utilities that can be used within `inline` methods (for example to improve error reporting), without having to define a macro.
 
-- Starting from `inline`-methods, [macros](scala-3-macros) are programs that
-  explicitly operate on trees of programs.
+- Starting from `inline`-methods, [macros](scala-3-macros) are programs that explicitly operate on trees of programs.
 
-  - Macros can be defined in terms of a _high-level_ API of [quoted expressions](quoted-code),
-    that admits simple construction and deconstruction of programs.
+  - Macros can be defined in terms of a _high-level_ API of [quoted expressions](quoted-code), that admits simple construction and deconstruction of programs.
 
-  - Macros can also be defined in terms of a more _low-level_ API of [TASTy Reflection](tasty-reflection),
-    that allows detailed inspection of programs.
+  - Macros can also be defined in terms of a more _low-level_ API of [TASTy Reflection](tasty-reflection), that allows detailed inspection of programs.
 
 
 > 🚧 We are still in the process of writing the tutorial. You can [help us improve it][contributing] 🚧

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -5,12 +5,12 @@ title: Introduction
 
 This tutorial covers all the features involved in writing macros in Scala 3.
 We will start with the new `inline` feature which is the entry point of all macros.
-We also cover some meetaprogramming features that can be used with `inline`.
+We also cover some metaprogramming features that can be used with `inline`.
 Then we learn how to create a macro using `inline` and quoted expressions.
 We will have a look at the _quoted expressions_ API and how to use them.
 Finally, for those macros that need a bit more than expression, we will learn how to access thier typed AST.
 
-🚧 We are still in the process of writing the turorial. You can [help us improve it][contributing] 🚧
+🚧 We are still in the process of writing the tutorial. You can [help us improve it][contributing] 🚧
 
 [inline]: tutorial/inline.md
 [contributing]: contributing.md

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -12,7 +12,7 @@ abstractions and offers more fine-grained control.
 - As a starting point, the new [`inline` feature](inline) allows some abstractions (values and methods) to be marked as statically reducible. 
   It can be used to optimize performance by specializing code and also provides the entry point for macros.
 
-- [Compile-time operations](compile-time-operations) offer additional metaprogramming utilities that can be used within `inline` methods (for example to improve error reporting), without having to define a macro.
+- [Compile-time operations](compiletime) offer additional metaprogramming utilities that can be used within `inline` methods (for example to improve error reporting), without having to define a macro.
 
 - Starting from `inline`-methods, [macros](scala-3-macros) are programs that explicitly operate on trees of programs.
 
@@ -25,3 +25,5 @@ abstractions and offers more fine-grained control.
 
 [inline]: tutorial/inline.md
 [contributing]: contributing.md
+[compiletime]: tutorial/compiletime.md
+

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -4,13 +4,30 @@ title: Introduction
 ---
 
 This tutorial covers all the features involved in writing macros in Scala 3.
-We will start with the new `inline` feature which is the entry point of all macros.
-We also cover some metaprogramming features that can be used with `inline`.
-Then we learn how to create a macro using `inline` and quoted expressions.
-We will have a look at the _quoted expressions_ API and how to use them.
-Finally, for those macros that need a bit more than expression, we will learn how to access thier typed AST.
+The metaprogramming API of Scala 3 is designed in layers to gradually
+support different levels of use-cases. Each successive layer exposes additional
+abstractions and offers more fine-grained control.
 
-🚧 We are still in the process of writing the tutorial. You can [help us improve it][contributing] 🚧
+- As a starting point, the new [`inline` feature](inline) allows some abstractions
+  (values and methods) to be marked as statically reducible. It can be used to
+  optimize performance by specializing code and also provides the entry point
+  for macros.
+
+- [Compile-time operations](compile-time-operations) offer additional metaprogramming
+  utilities that can be used within `inline` methods (for example to improve error reporting),
+  without having to define a macro.
+
+- Starting from `inline`-methods, [macros](scala-3-macros) are programs that
+  explicitly operate on trees of programs.
+
+- Macros can be defined in terms of a _high-level_ API of [quoted expressions](quoted-code),
+  that admits simple construction and deconstruction of programs.
+
+- Macros can also be defined in terms of a more _low-level_ API of [TASTy Reflection](tasty-reflection),
+  that allows detailed inspection of programs.
+
+
+> 🚧 We are still in the process of writing the tutorial. You can [help us improve it][contributing] 🚧
 
 [inline]: tutorial/inline.md
 [contributing]: contributing.md

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -9,16 +9,16 @@ The metaprogramming API of Scala 3 is designed in layers to gradually
 support different levels of use-cases. Each successive layer exposes additional
 abstractions and offers more fine-grained control.
 
-- As a starting point, the new [`inline` feature](inline) allows some abstractions (values and methods) to be marked as statically reducible. 
+- As a starting point, the new [`inline` feature](inline.md) allows some abstractions (values and methods) to be marked as statically reducible. 
   It can be used to optimize performance by specializing code and also provides the entry point for macros.
 
-- [Compile-time operations](compiletime) offer additional metaprogramming utilities that can be used within `inline` methods (for example to improve error reporting), without having to define a macro.
+- [Compile-time operations](compiletime.md) offer additional metaprogramming utilities that can be used within `inline` methods (for example to improve error reporting), without having to define a macro.
 
-- Starting from `inline`-methods, [macros](scala-3-macros) are programs that explicitly operate on trees of programs.
+- Starting from `inline`-methods, [macros](macros.md) are programs that explicitly operate on trees of programs.
 
-  - Macros can be defined in terms of a _high-level_ API of [quoted expressions](quoted-code), that admits simple construction and deconstruction of programs.
+  - Macros can be defined in terms of a _high-level_ API of [quoted expressions](quotes.md), that admits simple construction and deconstruction of programs.
 
-  - Macros can also be defined in terms of a more _low-level_ API of [TASTy Reflection](tasty-reflection), that allows detailed inspection of programs.
+  - Macros can also be defined in terms of a more _low-level_ API of [TASTy Reflection](tasty-reflection.md), that allows detailed inspection of programs.
 
 
 > 🚧 We are still in the process of writing the tutorial. You can [help us improve it][contributing] 🚧

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -20,11 +20,11 @@ abstractions and offers more fine-grained control.
 - Starting from `inline`-methods, [macros](scala-3-macros) are programs that
   explicitly operate on trees of programs.
 
-- Macros can be defined in terms of a _high-level_ API of [quoted expressions](quoted-code),
-  that admits simple construction and deconstruction of programs.
+  - Macros can be defined in terms of a _high-level_ API of [quoted expressions](quoted-code),
+    that admits simple construction and deconstruction of programs.
 
-- Macros can also be defined in terms of a more _low-level_ API of [TASTy Reflection](tasty-reflection),
-  that allows detailed inspection of programs.
+  - Macros can also be defined in terms of a more _low-level_ API of [TASTy Reflection](tasty-reflection),
+    that allows detailed inspection of programs.
 
 
 > 🚧 We are still in the process of writing the tutorial. You can [help us improve it][contributing] 🚧

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -10,13 +10,13 @@ support different levels of use-cases. Each successive layer exposes additional
 abstractions and offers more fine-grained control.
 
 - As a starting point, the new [`inline` feature](inline.md) allows some abstractions (values and methods) to be marked as statically reducible. 
-  It can be used to optimize performance by specializing code and also provides the entry point for macros.
+  It provides the entry point for macros and other metaprogramming utilities.
 
 - [Compile-time operations](compiletime.md) offer additional metaprogramming utilities that can be used within `inline` methods (for example to improve error reporting), without having to define a macro.
 
-- Starting from `inline`-methods, [macros](macros.md) are programs that explicitly operate on trees of programs.
+- Starting from `inline`-methods, [macros](macros.md) are programs that explicitly operate on programs.
 
-  - Macros can be defined in terms of a _high-level_ API of [quoted expressions](quotes.md), that admits simple construction and deconstruction of programs.
+  - Macros can be defined in terms of a _high-level_ API of [quoted expressions](quotes.md), that admits simple construction and deconstruction of programs expressions.
 
   - Macros can also be defined in terms of a more _low-level_ API of [TASTy Reflection](tasty-reflection.md), that allows detailed inspection of programs.
 

--- a/docs/tutorial/tasty-reflection.md
+++ b/docs/tutorial/tasty-reflection.md
@@ -20,10 +20,10 @@ def pow(x: Expr[Int])(using QuoteContext): Expr[Int] = {
 
 This will import all the types and modules (with extension methods) of the API.
 
-The full imported API can be found here: [Reflection](http://dotty.epfl.ch/api/scala/tasty/Reflection.html)
+The full imported API can be found here: [Reflection](https://dotty.epfl.ch/api/scala/tasty/Reflection.html)
 
 For example to find what is a `Term`, we can see in the hierarchy that it is a subtype of `Statement` which is a subtype of `Tree`.
-If we look into the [`TermMethods`](http://dotty.epfl.ch/api/scala/tasty/Reflection/TermMethods.html) we will find all the extension methods that are defined for `Term` such as `Term.tpe` which returns a `Type`.
+If we look into the [`TermMethods`](https://dotty.epfl.ch/api/scala/tasty/Reflection/TermMethods.html) we will find all the extension methods that are defined for `Term` such as `Term.tpe` which returns a `Type`.
 As it is a subtype of `Tree` we can also look into the [`TreeMethods`](http://dotty.epfl.ch/api/scala/tasty/Reflection/TreeMethods.html) to find more methods such as `Tree.pos`.
 Each type also a module with some _static-ish_ methods, for example in the [TypeModule](http://dotty.epfl.ch/api/scala/tasty/Reflection/TypeModule.html) we can find the method `Type.of[T]` with will create an instance of `Type` containing `T`.
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -17,32 +17,11 @@
       "faq": {
         "title": "FAQ"
       },
-      "get-started": {
-        "title": "Scala 3 macros tutorial"
-      },
-      "inline": {
-        "title": "Inline"
-      },
-      "scala-3-macros": {
-        "title": "Scala 3 macros"
-      },
-      "other-recources": {
-        "title": "Other Recources"
-      },
-      "quoted-code": {
-        "title": "Quoted Code"
-      },
-      "tasty-reflection": {
-        "title": "TASTy Reflection"
-      },
-      "tutorial/compile-time-operations": {
-        "title": "Scala Compile-time Operations"
+      "tutorial/introduction": {
+        "title": "Introduction"
       },
       "tutorial/inline": {
         "title": "Inline"
-      },
-      "tutorial/introduction": {
-        "title": "Introduction"
       },
       "tutorial/scala-3-macros": {
         "title": "Scala 3 Macros"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -6,7 +6,7 @@
     "tagline": "A tutorial to cover all the features involved in writing macros in Scala 3",
     "docs": {
       "best-practices": {
-        "title": "Best practices"
+        "title": "Best Practices"
       },
       "compile-time-operations": {
         "title": "Compile-time operations"
@@ -17,14 +17,35 @@
       "faq": {
         "title": "FAQ"
       },
-      "tutorial/introduction": {
-        "title": "Introduction"
+      "get-started": {
+        "title": "Scala 3 macros tutorial"
+      },
+      "inline": {
+        "title": "Inline"
+      },
+      "scala-3-macros": {
+        "title": "Scala 3 macros"
+      },
+      "other-recources": {
+        "title": "Other Recources"
+      },
+      "quoted-code": {
+        "title": "Quoted Code"
+      },
+      "tasty-reflection": {
+        "title": "TASTy Reflection"
+      },
+      "tutorial/compile-time-operations": {
+        "title": "Scala Compile-time Operations"
       },
       "tutorial/inline": {
         "title": "Inline"
       },
+      "tutorial/introduction": {
+        "title": "Introduction"
+      },
       "tutorial/scala-3-macros": {
-        "title": "Scala 3 macros"
+        "title": "Scala 3 Macros"
       },
       "tutorial/quoted-code": {
         "title": "Quoted Code"
@@ -40,7 +61,7 @@
     },
     "categories": {
       "Tutorial": "Tutorial",
-      "Other": "Other"
+      "Extra": "Extra"
     }
   },
   "pages-strings": {

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -100,7 +100,7 @@ const Metaprogramming = () => (
         content:
           'Scala 3 provides a toolbox full of metaprogramming features, which are safer, more robust, and much more stable than their counterparts in Scala 2. ' +
           'Implementing macro libraries in Scala 3 is simpler and the resulting libraries are easier to maintain across future versions of Scala. ' +
-          'The improvements come at a price: the meta-programming facilities have been re-designed from the _ground up_. In consequence, existing macro libraries need to be ported to the new interfaces.\n\n' +
+          'The improvements come at a price: the metaprogramming facilities have been re-designed from the _ground up_. In consequence, existing macro libraries need to be ported to the new interfaces.\n\n' +
           `In the [Migrating Macros](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/migrating-macros.html) section, ` +
           'you will find helpful content to port your macros code to Scala 3.',
         title: `[Migrating Macros](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/migrating-macros.html)`,

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -98,9 +98,9 @@ const Metaprogramming = () => (
     {[
       {
         content:
-          'Scala 3 metaprogramming features are safer, more robust and much more stable than the Scala 2 macro mechanisms. ' +
-          'Existing macro libraries will turn out to be much more simple. ' +
-          'But it comes at the price of re-implementing the macro methods from the ground up.\n\n' +
+          'Scala 3 provides a toolbox full of metaprogramming features, which are safer, more robust, and much more stable than their counterparts in Scala 2. ' +
+          'Implementing macro libraries in Scala 3 is simpler and the resulting libraries are easier to maintain across future versions of Scala. ' +
+          'The improvements come at a price: the meta-programming facilities have been re-designed from the _ground up_. In consequence, existing macro libraries need to be ported to the new interfaces.\n\n' +
           `In the [Migrating Macros](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/migrating-macros.html) section, ` +
           'you will find helpful content to port your macros code to Scala 3.',
         title: `[Migrating Macros](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/migrating-macros.html)`,


### PR DESCRIPTION
I started reviewing the documentation by reviewing the first page and the inline section.

Here are a few additional comments:


## Introduction

> for those macros that need a bit more than expression

In this context it is not clear what is meant by "expression".


## Inline

> Scala 3 makes several improvements related to inlining:

improvements over what? I assumed Scala 2 in my rephrasing 

- "literal type" -- TODO link to docs!

- inline and transparent are not rendered as keyword

### Inline Methods

> We use an `inline` parameter to enforce this requirement

Is this true? It could still be an unknown variable, right? I dropped this sentence


### Inline Method Overriding

> same signature

The return type can be refined though, right?


### Abstract inline methods
```scala
logged(new PrintLogger, "🥧")
// inlined as
val logger: PrintLogger = new PrintLogger
logger.log(x)
```
The type of the argument is refined to `PrintLogger` which does not sound like it meets the semantics preservation as described in the earlier section.

### Transparent inline methods
Maybe we want to move them as a subsection to Inline Methods???

### scala.compiletime & Macros 
I think this part should only serve as a teaser to the next Section. So maybe we can just say what's there to improve working with inlines and then point to the next sections?
