### PR TITLE
Add disclaimer

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -2,6 +2,7 @@
 id: best-practices
 title: Best Practices
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
 
 ## Inline
 
@@ -59,3 +60,5 @@ val y: Expr[Int] = ...
 
 ## TASTy reflection
 **Coming soon**
+
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,7 @@
 id: contributing
 title: Contributing
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
 
 We are starting to write the initial draft of the macro tutorial. 
 Help improving text that has been written so far would be helpful at this point.
@@ -45,3 +46,4 @@ Additionally, we will include a cross-compilation/migration guide (M-A).
 [references]: references.md
 [tasty]: tutorial/reflection.md
 [reflection-api]: https://github.com/lampepfl/dotty/blob/master/library/src/scala/tasty/Reflection.scala
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,7 +40,7 @@ Additionally, we will include a cross-compilation/migration guide (M-A).
 [faq]: faq.md
 [inline]: tutorial/inline.md
 [macros]: tutorial/macros.md
-[migration-status]: https://scalacenter.github.io/scala-3-migration-guide/docs/macros/migration-status.html
+[migration-status]: https://scalacenter.github.io/scala-3-migration-guide/docs/macros/macro-libraries.html
 [quotes]: tutorial/quotes.md
 [references]: references.md
 [tasty]: tutorial/reflection.md

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,6 +2,7 @@
 id: faq
 title: FAQ
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
 
 ## Which should I use `Expr(...)` or `'{...}`?
 If you can write your code using `Expr(...)`, you will evaluate more at compile time.
@@ -22,3 +23,4 @@ x match
   case '{ $x: t } =>
     // `x: Expr[X & t]` where `t` is the precise type of `x`
 ```
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/docs/other-recources.md
+++ b/docs/other-recources.md
@@ -2,6 +2,7 @@
 id: other-recources
 title: Other Recources
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
 
 ## Scala 2 migration
  * [Scala 2 migration and cross-compilation][migration]
@@ -33,3 +34,4 @@ title: Other Recources
 [quotes]: tutorial/quotes.md
 [references]: references.md
 [tasty]: tutorial/reflection.md
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/docs/tutorial/compiletime.md
+++ b/docs/tutorial/compiletime.md
@@ -2,6 +2,7 @@
 id: compile-time-operations
 title: Scala Compile-time Operations
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
 
 Operations in [scala.compiletime][compiletime-api] are metaprogramming operations that can be used within an `inline` method.
 These operation do cover some common use cases of macros without you needing to define a macro.
@@ -78,3 +79,4 @@ Summon all provides a way to summon multiple values at the same time from a tupl
 [references]: references.md
 [tasty]: tutorial/reflection.md
 [compiletime-api]: https://dotty.epfl.ch/api/scala/compiletime/index.html
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/docs/tutorial/inline.md
+++ b/docs/tutorial/inline.md
@@ -2,7 +2,6 @@
 id: inline
 title: Inline
 ---
-
 Inlining is a common compile-time metaprogramming technique, typically used to achieve performance optimizations. As we will see, in Scala 3, the concept of inlining provides us with an entrypoint to programming with macros.
 
 1. It introduces inline as a [soft keyword][soft-modifier].

--- a/docs/tutorial/inline.md
+++ b/docs/tutorial/inline.md
@@ -2,6 +2,8 @@
 id: inline
 title: Inline
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
+
 Inlining is a common compile-time metaprogramming technique, typically used to achieve performance optimizations. As we will see, in Scala 3, the concept of inlining provides us with an entrypoint to programming with macros.
 
 1. It introduces inline as a [soft keyword][soft-modifier].
@@ -490,3 +492,4 @@ def powerCode(x: Expr[Double], n: Expr[Int])(using Quotes): Expr[Double] = ...
 [macros]: tutorial/macros.md
 [references]: references.md
 [soft-modifier]: https://dotty.epfl.ch/docs/reference/soft-modifier.html
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -2,6 +2,7 @@
 id: introduction
 title: Introduction
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
 
 This tutorial covers all the features involved in writing macros in Scala 3.
 
@@ -24,9 +25,7 @@ abstractions and offers more fine-grained control.
 
 > The tutorial uses the API of Scala 3.0.0-M3. The API had many small changes in this revision.
 
-> 🚧 We are still in the process of writing the tutorial. You can [help us improve it][contributing] 🚧
-
 [inline]: tutorial/inline.md
 [contributing]: contributing.md
 [compiletime]: tutorial/compiletime.md
-
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/docs/tutorial/macros.md
+++ b/docs/tutorial/macros.md
@@ -2,6 +2,7 @@
 id: scala-3-macros
 title: Scala 3 Macros
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
 
 [Inline methods][inline] provide us with a elegant technique for metaprogramming by performing some operations at compile time.
 However, sometimes inlining is not enough and we need more powerful ways to analyze and synthesize programs at compile time.
@@ -277,3 +278,4 @@ The subsequent section on [Quoted Code][quotes] presents quotes in more detail.
 [quotes]: tutorial/quotes.md
 [references]: other-resources.md
 [tasty]: tutorial/reflection.md
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/docs/tutorial/quotes.md
+++ b/docs/tutorial/quotes.md
@@ -2,6 +2,7 @@
 id: quoted-code
 title: Quoted Code
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
 
 ## Code blocks
 A quoted code block `'{ ... }` is syntactically similar to a string quote `" ... "` with the difference that the first contains typed code.
@@ -394,3 +395,4 @@ Here we used `HashSet` and another valid implementation that does not need the `
 [quotes]: tutorial/quotes.md
 [references]: references.md
 [tasty]: tutorial/reflection.md
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/docs/tutorial/reflection.md
+++ b/docs/tutorial/reflection.md
@@ -1,7 +1,8 @@
 ---
 id: reflection
-title: Reflection API 
+title: Reflection API
 ---
+> The macro tutorial has been moved to [docs.scala-lang.org][scala-lang] and this page is no longer updated.
 
 The reflection API provides a more complex and comprehensive view on the structure of the code.
 It provides a view on the *Typed Abstract Syntax Trees* **TASTy** and their properties such as types, symbols, positions and comments.
@@ -38,3 +39,5 @@ Each type also a module with some _static-ish_ methods, for example in the [Type
 
 ## Examples
 *Coming soon*
+
+[scala-lang]: https://docs.scala-lang.org/scala3/guides/macros/

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -83,6 +83,7 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle />
           <PromoSection>
+            <blockquote>The macro tutorial has been moved to <a href="https://docs.scala-lang.org/scala3/guides/macros/">docs.scala-lang.org</a> and this page is no longer updated.</blockquote>
             <Button href={docUrl("tutorial/introduction.html", language)}>
               Tutorial
             </Button>

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -101,9 +101,9 @@ const Metaprogramming = () => (
           'Scala 3 provides a toolbox full of metaprogramming features, which are safer, more robust, and much more stable than their counterparts in Scala 2. ' +
           'Implementing macro libraries in Scala 3 is simpler and the resulting libraries are easier to maintain across future versions of Scala. ' +
           'The improvements come at a price: the metaprogramming facilities have been re-designed from the _ground up_. In consequence, existing macro libraries need to be ported to the new interfaces.\n\n' +
-          `In the [Migrating Macros](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/migrating-macros.html) section, ` +
+          `In the [Migrating Macros](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/macro-libraries.html) section, ` +
           'you will find helpful content to port your macros code to Scala 3.',
-        title: `[Migrating Macros](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/migrating-macros.html)`,
+        title: `[Migrating Macros](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/macro-libraries.html)`,
         image: `${imgUrl('magnifying-primary.svg')}`,
         imageAlt: 'Icon made by Eucalyp from the Noun Project.',
         imageAlign: 'left',


### PR DESCRIPTION
We migrated the contents to the official docs.scala-lang.org page.

This PR adds a notice about this migration.